### PR TITLE
fix: build.proj should only build src projects.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,9 +2,12 @@
     <PropertyGroup>
         <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     </PropertyGroup>
+    <ItemGroup>
+        <ProjectReferences Include="src\*.*proj" />
+    </ItemGroup>
     <Target Name="build">
-        <MSBuild Projects="AWS.SessionProvider.sln"
-            Targets="Clean;Build" 
+        <MSBuild Projects="@(ProjectReferences)"
+            Targets="Build"
             Properties="Configuration=$(Configuration)" />
     </Target>
 </Project>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
