### PR TITLE
Update AWS SDKs nuget spec upper bound to 4.0

### DIFF
--- a/AWS.SessionProvider.nuspec
+++ b/AWS.SessionProvider.nuspec
@@ -11,7 +11,7 @@
     <tags>AWS Amazon cloud</tags>
     <iconUrl>http://media.amazonwebservices.com/aws_singlebox_01.png</iconUrl>
     <dependencies>
-	  <dependency id="AWSSDK.DynamoDBv2" version="[3.3.4.0, 3.4)" />
+	  <dependency id="AWSSDK.DynamoDBv2" version="[3.3.4.0, 4.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
To allow usage of AWSSDKs with version less than equal to 4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
