### PR TITLE
Update nuget.exe to version 5.5.1.6542

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -58,7 +58,8 @@
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
 
-        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT'">"$(SolutionDir) "</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT' and HasTrailingSlash('$(SolutionDir)')">"$(SolutionDir)\"</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT' and !HasTrailingSlash('$(SolutionDir)')">"$(SolutionDir)"</PaddedSolutionDir>
         <PaddedSolutionDir Condition=" '$(OS)' != 'Windows_NT' ">"$(SolutionDir)"</PaddedSolutionDir>
 
         <!-- Commands -->


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Update nuget.exe to latest version as recommended on https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/.

The new nuget.exe breaks relative path for SolutionDir which is solved using [workaround](https://github.com/NuGet/Home/issues/7657#issuecomment-469901706).

Local build succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
