### PR TITLE
Add icon and license to nuspec

### DIFF
--- a/AWS.SessionProvider.nuspec
+++ b/AWS.SessionProvider.nuspec
@@ -6,10 +6,14 @@
     <authors>Amazon Web Services</authors>
     <description>This contains a session state provider using Amazon DynamoDB.</description>
     <language>en-US</language>
+    <!-- Remove licenseUrl when NuGet v5.3 is used-->
     <licenseUrl>http://aws.amazon.com/apache2.0/</licenseUrl>
+    <license type="file">License.txt</license>
     <projectUrl>https://github.com/aws/aws-dotnet-session-provider/</projectUrl>
     <tags>AWS Amazon cloud</tags>
+    <!-- Remove iconUrl when NuGet v5.3 is used-->
     <iconUrl>http://media.amazonwebservices.com/aws_singlebox_01.png</iconUrl>
+    <icon>icon.png</icon>
     <dependencies>
 	  <dependency id="AWSSDK.DynamoDBv2" version="3.5.1.9" />
     </dependencies>
@@ -21,5 +25,8 @@
     <file src=".\src\bin\net45\Release v4.5\AWS.SessionProvider.pdb" target="lib\net45" />
 
     <file src="aws-sessionprovider-sample.config" target="content" />
+
+    <file src="License.txt" target="" />
+    <file src="icon.png" target="" />
   </files>
 </package>


### PR DESCRIPTION
*Description of changes:*

Add license and icon to nuspec due to deprecated licenseUrl and iconUrl. Leave licenseUrl and iconUrl for now until NuGet 5.3 is used universally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
