### PR TITLE
Update two more AWSSDK dependencies to 3.7

### DIFF
--- a/src/AWS.SessionProvider.Net35.csproj
+++ b/src/AWS.SessionProvider.Net35.csproj
@@ -71,11 +71,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.Core.3.5.1.31\lib\net35\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.7.0.2\lib\net35\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.DynamoDBv2, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.5.1.9\lib\net35\AWSSDK.DynamoDBv2.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.7.0.2\lib\net35\AWSSDK.DynamoDBv2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update two additional AWS SDK dependencies I had missed in PR #24.

I had originally tested by building in Visual Studio, and likely not with a clean folder. 

Confirmed that with this change a `msbuild build.proj` is now successful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
