### PR TITLE
Fix build errors

### DIFF
--- a/src/DynamoDBSessionStateStore.cs
+++ b/src/DynamoDBSessionStateStore.cs
@@ -306,8 +306,8 @@ namespace Amazon.SessionProvider
 
         private static string GetAssemblyFileVersion()
         {
-            var assembly = typeof(DynamoDBSessionStateStore).GetTypeInfo().Assembly;
-            AssemblyFileVersionAttribute attribute = assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
+            var assembly = typeof(DynamoDBSessionStateStore).Assembly;
+            var attribute = assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
 
             var version = attribute == null ? "Unknown" : attribute.Version;
             return version;


### PR DESCRIPTION
*Description of changes:*
Removed the usage of `Type.GetTypeInfo()` since it is not available in .NET Framework 3.5. 
Verified that the assembly file version can still be resolved correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
