### PR TITLE
Use GetCustomAttribute from the Attribute class

### DIFF
--- a/src/DynamoDBSessionStateStore.cs
+++ b/src/DynamoDBSessionStateStore.cs
@@ -17,11 +17,9 @@ using System.IO;
 using System.Web;
 using System.Web.Configuration;
 using System.Configuration;
-using System.Configuration.Provider;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Web.SessionState;
-using System.Text;
 using System.Threading;
 
 using Amazon.DynamoDBv2;
@@ -29,7 +27,6 @@ using Amazon.DynamoDBv2.Model;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal.Util;
-using Amazon.Util;
 using System.Reflection;
 
 namespace Amazon.SessionProvider
@@ -307,7 +304,7 @@ namespace Amazon.SessionProvider
         private static string GetAssemblyFileVersion()
         {
             var assembly = typeof(DynamoDBSessionStateStore).Assembly;
-            var attribute = assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
+            var attribute = (AssemblyFileVersionAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyFileVersionAttribute));
 
             var version = attribute == null ? "Unknown" : attribute.Version;
             return version;


### PR DESCRIPTION
*Description of changes:*
The [GetCustomAttributes(Assembly, Type)](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributeextensions.getcustomattributes?view=net-8.0#system-reflection-customattributeextensions-getcustomattributes(system-reflection-assembly-system-type)) extension method is not available in .NET framework 3.5. This PR replaces it with the [GetCustomAttribute(Assembly, Type)](https://learn.microsoft.com/en-us/dotnet/api/system.attribute.getcustomattribute?view=net-8.0#system-attribute-getcustomattribute(system-reflection-assembly-system-type)) static method from the Attribute class.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
